### PR TITLE
Provide fix to dotenv falsy variables

### DIFF
--- a/will_of_the_prophets/settings.py
+++ b/will_of_the_prophets/settings.py
@@ -9,12 +9,14 @@ import django_heroku
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
+from .utils import get_boolean_env_variable
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # noqa: PTH100, PTH120
 
 SECRET_KEY = os.environ.get("SECRET_KEY", "placeholder")
 
-DEBUG = bool(os.environ.get("DEBUG", False))
+DEBUG = get_boolean_env_variable("DEBUG", False)
 
 ALLOWED_HOSTS = ["*.herokuapp.com", "localhost"]
 
@@ -49,7 +51,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-if bool(os.environ.get("DISABLE_DEBUG_TOOLBAR", False)):
+if get_boolean_env_variable("DISABLE_DEBUG_TOOLBAR", False):
     INSTALLED_APPS.remove("debug_toolbar")
     MIDDLEWARE.remove("debug_toolbar.middleware.DebugToolbarMiddleware")
 
@@ -138,7 +140,7 @@ IGNORABLE_404_URLS = [re.compile(r"^/phpmyadmin/"), re.compile(r"\.php$")]
 # Security
 # https://docs.djangoproject.com/en/stable/topics/security/
 
-SECURE_SSL_REDIRECT = bool(os.environ.get("SECURE_SSL_REDIRECT", not DEBUG))
+SECURE_SSL_REDIRECT = get_boolean_env_variable("SECURE_SSL_REDIRECT", not DEBUG)
 SECURE_HSTS_SECONDS = int(
     os.environ.get(
         "SECURE_HSTS_SECONDS",
@@ -210,7 +212,7 @@ CSP_STYLE_SRC = ["'self'", "cdnjs.cloudflare.com"]
 CSP_IMG_SRC = ["'self'", "s3.amazonaws.com", "s3.us-east-1.amazonaws.com"]
 CSP_SCRIPT_SRC = ["'self'", "browser.sentry-cdn.com", "cdnjs.cloudflare.com"]
 CSP_CONNECT_SRC = ["'self'", "s3.us-east-1.amazonaws.com"]
-CSP_REPORT_ONLY = bool(os.environ.get("CSP_REPORT_ONLY", DEBUG))
+CSP_REPORT_ONLY = get_boolean_env_variable("CSP_REPORT_ONLY", DEBUG)
 CSP_REPORT_URI = os.environ.get("CSP_REPORT_URI", None)
 CSP_INCLUDE_NONCE_IN = ["script-src", "style-src"]
 

--- a/will_of_the_prophets/tests/test_utils.py
+++ b/will_of_the_prophets/tests/test_utils.py
@@ -1,0 +1,27 @@
+import os
+import pytest
+from unittest.mock import patch
+
+from ..utils import get_boolean_env_variable
+
+
+@pytest.mark.parametrize(
+    "env_value, fallback_value, expected_result",
+    [
+        ("1", False, True),
+        ("0", True, False),
+        ("true", False, True),
+        ("false", True, False),
+        ("yes", False, True),
+        ("no", True, False),
+    ],
+)
+def test_get_boolean_env_variable(env_value, fallback_value, expected_result):
+    with patch.dict(os.environ, {"TEST_VAR": env_value}):
+        assert get_boolean_env_variable("TEST_VAR", fallback_value) == expected_result
+
+
+def test_get_boolean_env_variable_fallback():
+    with patch.dict(os.environ, {}, clear=True):
+        assert get_boolean_env_variable("TEST_VAR", True) == True
+        assert get_boolean_env_variable("TEST_VAR", False) == False

--- a/will_of_the_prophets/tests/test_utils.py
+++ b/will_of_the_prophets/tests/test_utils.py
@@ -1,12 +1,13 @@
 import os
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 from ..utils import get_boolean_env_variable
 
 
 @pytest.mark.parametrize(
-    "env_value, fallback_value, expected_result",
+    ("env_value", "fallback_value", "expected_result"),
     [
         ("1", False, True),
         ("0", True, False),
@@ -16,12 +17,12 @@ from ..utils import get_boolean_env_variable
         ("no", True, False),
     ],
 )
-def test_get_boolean_env_variable(env_value, fallback_value, expected_result):
+def test_get_boolean_env_variable(env_value, fallback_value, expected_result) -> None:
     with patch.dict(os.environ, {"TEST_VAR": env_value}):
         assert get_boolean_env_variable("TEST_VAR", fallback_value) == expected_result
 
 
-def test_get_boolean_env_variable_fallback():
+def test_get_boolean_env_variable_fallback() -> None:
     with patch.dict(os.environ, {}, clear=True):
         assert get_boolean_env_variable("TEST_VAR", True) == True
         assert get_boolean_env_variable("TEST_VAR", False) == False

--- a/will_of_the_prophets/utils.py
+++ b/will_of_the_prophets/utils.py
@@ -1,0 +1,35 @@
+import os
+from distutils.util import strtobool
+
+
+def get_boolean_env_variable(var_name: str, fallback_value: bool) -> bool:
+    """
+    Retrieves an environment variable with a boolean value and converts
+    it to a boolean for use within this project.
+
+    The reason that I've written this method is that .env files can cause problems
+    when loading environment variables e.g. DEBUG=0 or DEBUG=False within
+    .env can become DEBUG='false' (i.e. the string 'false') within
+    e.g. settings.py.  This in turn causes problems e.g. bool('false')=True
+
+    This method fetches the environment variable specified by `var_name`.
+    If the variable is not found, it uses the `fallback_value` provided.
+    The method then converts the string representation of the environment
+    variable to a boolean.
+
+    Args:
+        var_name (str): The name of the environment variable.
+        fallback_value (bool): The fallback value if the environment variable is not found.
+
+    Returns:
+        bool: The boolean value of the environment variable or the fallback value.
+    """
+    # Get the environment variable as a string, or use the fallback value if not set
+    env_var = os.environ.get(var_name, str(fallback_value))
+
+    try:
+        # Convert the string representation to a boolean
+        return bool(strtobool(env_var))
+    except ValueError:
+        # If strtobool fails, return the fallback_value
+        return fallback_value


### PR DESCRIPTION
### Purpose of PR
This PR allows us to add falsy variables such as `0` and `False` as environment variables and have Django accept them as intended.  The current behaviour translates these variables into the string `'false'` within Django and `bool('false')=True`. Not ideal.

### Referenced issue
This PR addresses issue https://github.com/craiga/will-of-the-prophets/issues/1527